### PR TITLE
Reformulate to NGINX to support easy ACME integration.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,11 +19,11 @@ let
     in folded.items
   );
   makeContainerDef = (name: value: nameValuePair "c${value.slug}" {
-      config = value.config; # TODO inherit config (value);
-      autoStart = true;
-      privateNetwork = true;
-      hostAddress = "192.168.100.10";
-      localAddress = "${value.ip}";
+    inherit (value) config;
+    autoStart = true;
+    privateNetwork = true;
+    hostAddress = "192.168.100.10";
+    localAddress = "${value.ip}";
   });
 in {
   options = {
@@ -32,51 +32,8 @@ in {
         type = types.bool;
         default = false;
       };
-      acceptTOS = mkOption {
-        type = types.bool;
-        default = false; # Just to force people to enable
-      };
-      adminAddr = mkOption {
-        type = types.str;
-      };
       rootDomain = mkOption {
         type = types.str;
-      };
-      enableACMERoot = mkOption {
-        type = types.bool;
-        default = false;
-      };
-      forceSSLRoot = mkOption {
-        type = types.bool;
-        default = true;
-      };
-      recommendedOptimisation = mkOption {
-        type = types.bool;
-        default = true;
-      };
-      recommendedTlsSettings = mkOption {
-        type = types.bool;
-        default = true;
-      };
-      recommendedGzipSettings = mkOption {
-        type = types.bool;
-        default = true;
-      };
-      hsts = mkOption {
-        type = types.str;
-        default = "add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains\" always;";
-      };
-      sslCertificateRoot = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-      };
-      sslTrustedCertificate = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-      };
-      sslCertificateKey = mkOption {
-        type = types.nullOr types.path;
-        default = null;
       };
       containers = mkOption {
         type = types.attrsOf (types.submodule {
@@ -88,27 +45,8 @@ in {
               type = types.str;
               default = "80";
             };
-            enableACME = mkOption {
-              type = types.bool;
-              default = false;
-            };
-            forceSSL = mkOption {
-              type = types.bool;
-              default = true;
-            };
-            sslCertificate = mkOption {
-              type = types.nullOr types.path;
-              default = null;
-            };
-            sslServerChain = mkOption {
-              type = types.nullOr types.path;
-              default = null;
-            };
-            sslServerKey = mkOption {
-              type = types.nullOr types.path;
-              default = null;
-            };
             config = mkOption {
+              # type = types.attrs; # TODO validate configs as submodules
               default = {};
             };
           };
@@ -121,39 +59,18 @@ in {
   (let
     withIps = addIps cfg.containers;
   in {
-    security.acme.acceptTerms = cfg.acceptTOS;
-    security.acme.email = cfg.adminAddr;
     containers = mapAttrs' makeContainerDef withIps;
     services.nginx = {
       enable = true;
-      recommendedTlsSettings = cfg.recommendedTlsSettings;
-      recommendedOptimisation = cfg.recommendedOptimisation;
-      recommendedGzipSettings = cfg.recommendedGzipSettings;
+      recommendedTlsSettings = true;
+      recommendedOptimisation = true;
+      recommendedGzipSettings = true;
       virtualHosts = (mapAttrs (name: value: {
-        serverName = name;
-        enableACME = value.enableACME;
-        forceSSL = value.forceSSL;
-        sslCertificate = if value.sslCertificate != null
-                         then value.sslCertificate
-                         else "/var/lib/acme/default/fullchain.pem";
-        sslCertificateKey = if value.sslServerKey != null
-                            then value.sslServerKey
-                            else "/var/lib/acme/default/key.pem";
-        sslTrustedCertificate = if value.sslServerChain != null
-                                then value.sslServerChain
-                                else "/var/lib/acme/default/full.pem";
-        extraConfig = ''
-          ${cfg.hsts}
-          proxy_set_header X-Forwarded-Host $host:$server_port;
-          proxy_set_header X-Forwarded-Server $host;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          location "/" {
-            proxy_pass "http://${value.ip}:${value.port}/";
-          }
-        '';
+        enableACME = true;
+        forceSSL = true;
+        locations."/".proxyPass = "http://${value.ip}:${value.port}/";
       }) withIps) // {
-        default = {
-          serverName = cfg.rootDomain;
+        ${cfg.rootDomain} = {
           root = let
             names = attrNames withIps;
             listItems = map (name: "<li><a href=\"//${name}\">${name}</a></li>\n") names;
@@ -165,19 +82,8 @@ in {
               ${str}
             </ul>
           '')}/home/";
-
-          enableACME = cfg.enableACMERoot;
-          forceSSL = cfg.forceSSLRoot;
-
-          sslCertificate = if value.sslCertificateRoot != null
-                           then value.sslCertificateRoot
-                           else "/var/lib/acme/default/fullchain.pem";
-          sslCertificateKey = if value.sslCertificateKey != null
-                              then value.sslCertificateKey
-                              else "/var/lib/acme/default/key.pem";
-          sslTrustedCertificate = if value.sslTrustedCertificate != null
-                                  then value.sslTrustedCertificate
-                                  else "/var/lib/acme/default/full.pem";
+          enableACME = true;
+          forceSSL = true;
         };
       };
     };

--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,15 @@ in {
         type = types.bool;
         default = true;
       };
+      recommendedOptimisation = mkOption {
+        type = types.bool;
+        default = true;
+      };
       recommendedTlsSettings = mkOption {
+        type = types.bool;
+        default = true;
+      };
+      recommendedGzipSettings = mkOption {
         type = types.bool;
         default = true;
       };
@@ -119,6 +127,8 @@ in {
     services.nginx = {
       enable = true;
       recommendedTlsSettings = cfg.recommendedTlsSettings;
+      recommendedOptimisation = cfg.recommendedOptimisation;
+      recommendedGzipSettings = cfg.recommendedGzipSettings;
       virtualHosts = (mapAttrs (name: value: {
         serverName = name;
         enableACME = value.enableACME;
@@ -142,23 +152,8 @@ in {
           }
         '';
       }) withIps) // {
-        home = {
-          serverName = cfg.rootDomain;
-          root = "${pkgs.writeTextDir "home/index.html" (readFile ./index.html)}/home/";
-          enableACME = cfg.enableACMERoot;
-          forceSSL = cfg.forceSSLRoot;
-          sslCertificate = if value.sslCertificateRoot != null
-                           then value.sslCertificateRoot
-                           else "/var/lib/acme/default/fullchain.pem";
-          sslCertificateKey = if value.sslCertificateKey != null
-                              then value.sslCertificateKey
-                              else "/var/lib/acme/default/key.pem";
-          sslTrustedCertificate = if value.sslTrustedCertificate != null
-                                  then value.sslTrustedCertificate
-                                  else "/var/lib/acme/default/full.pem";
-        };
         default = {
-          serverName = "default";
+          serverName = cfg.rootDomain;
           root = let
             names = attrNames withIps;
             listItems = map (name: "<li><a href=\"//${name}\">${name}</a></li>\n") names;
@@ -170,8 +165,10 @@ in {
               ${str}
             </ul>
           '')}/home/";
+
           enableACME = cfg.enableACMERoot;
           forceSSL = cfg.forceSSLRoot;
+
           sslCertificate = if value.sslCertificateRoot != null
                            then value.sslCertificateRoot
                            else "/var/lib/acme/default/fullchain.pem";


### PR DESCRIPTION
Note: I know hardly anything about how options work (and how to make them mutually exclusive, for example, `enableACME`, and supplying your own cert paths ...). This works but the options scheme is less than ideal. 